### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/LinkedInDemo/2354eb25-6d59-41a8-8c5f-b7cbe2c69c09/a59dbca6-55d8-47d5-9180-b3bf4be093d1/_apis/work/boardbadge/e464c84b-461b-456d-b3d3-d06e94c2b877)](https://dev.azure.com/LinkedInDemo/2354eb25-6d59-41a8-8c5f-b7cbe2c69c09/_boards/board/t/a59dbca6-55d8-47d5-9180-b3bf4be093d1/Microsoft.RequirementCategory)
 
 # Contributing
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4](https://dev.azure.com/LinkedInDemo/2354eb25-6d59-41a8-8c5f-b7cbe2c69c09/_workitems/edit/4). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.